### PR TITLE
After update fx.tar.xz is not removed

### DIFF
--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -119,7 +119,7 @@ else
                 sleep infinity
             fi
             tar -xf fx.tar.xz
-            rm ${SERVER_DIR}/$LAT_V/fx.tar.xz
+            rm -R fx.tar.xz
             touch fiveminstalled-$LAT_V
         elif [ "$LAT_V" == "$CUR_V" ]; then
             echo "---FiveM Version up-to-date---"


### PR DESCRIPTION
The rm command currently does not delete `fx.tar.xz` after a newer version is available. With this pr, the file gets removed as used by the first install step.